### PR TITLE
add claim support to bots

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -210,6 +210,7 @@ impl Bot {
                 Some(
                     if self.state.game.current_trick.is_empty()
                         && !self.state.game.claims.is_claiming(self.state.seat)
+                        && self.state.game.played.len() < 48
                         && must_claim(
                             self.state.post_pass_hand - self.state.game.played,
                             self.state.game.played,

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -4,7 +4,9 @@ use crate::{
     cards::Cards,
     error::CardsError,
     game::{event::GameEvent, id::GameId, state::GameState, Games},
+    rank::Rank,
     seat::Seat,
+    suit::Suit,
     user::UserId,
 };
 use log::debug;
@@ -97,8 +99,15 @@ impl Bot {
                         .await?
                 }
                 Some(Action::Play(card)) => {
-                    let complete = games.play_card(self.game_id, self.user_id, card).await?;
-                    if complete {
+                    if games.play_card(self.game_id, self.user_id, card).await? {
+                        return Ok(());
+                    }
+                }
+                Some(Action::Claim) => {
+                    games.claim(self.game_id, self.user_id).await?;
+                }
+                Some(Action::AcceptClaim(seat)) => {
+                    if let Ok(true) = games.accept_claim(self.game_id, self.user_id, seat).await {
                         return Ok(());
                     }
                 }
@@ -158,8 +167,17 @@ impl Bot {
             GameEvent::RecvPass { cards, .. } => {
                 self.state.post_pass_hand |= *cards;
             }
-            GameEvent::Claim { seat, .. } => {
-                return Some(Action::RejectClaim(*seat));
+            GameEvent::Claim { seat, hand } => {
+                return if *seat == self.state.seat {
+                    None
+                } else if can_claim(*hand, &self.state.game) {
+                    Some(Action::AcceptClaim(*seat))
+                } else {
+                    Some(Action::RejectClaim(*seat))
+                };
+            }
+            GameEvent::AcceptClaim { .. } => {
+                return None;
             }
             _ => {}
         }
@@ -186,7 +204,19 @@ impl Bot {
             if (self.state.post_pass_hand - self.state.game.played).contains(Card::TwoClubs)
                 || Some(self.state.seat) == self.state.game.next_player
             {
-                Some(Action::Play(self.algorithm.play(&self.state)))
+                Some(
+                    if self.state.game.current_trick.is_empty()
+                        && !self.state.game.claims.is_claiming(self.state.seat)
+                        && must_claim(
+                            self.state.post_pass_hand - self.state.game.played,
+                            self.state.game.played,
+                        )
+                    {
+                        Action::Claim
+                    } else {
+                        Action::Play(self.algorithm.play(&self.state))
+                    },
+                )
             } else {
                 None
             }
@@ -201,6 +231,8 @@ enum Action {
     Pass(Cards),
     Charge(Cards),
     Play(Card),
+    Claim,
+    AcceptClaim(Seat),
     RejectClaim(Seat),
 }
 
@@ -211,4 +243,136 @@ trait Algorithm {
     fn play(&mut self, state: &BotState) -> Card;
 
     fn on_event(&mut self, state: &BotState, event: &GameEvent);
+}
+
+fn must_claim(hand: Cards, played: Cards) -> bool {
+    let remaining = Cards::ALL - hand - played;
+    for suit in &[Cards::SPADES, Cards::HEARTS, Cards::DIAMONDS, Cards::CLUBS] {
+        let hand = hand & *suit;
+        let remaining = remaining & *suit;
+        if !hand.is_empty() && !remaining.is_empty() && hand.min() < remaining.max() {
+            return false;
+        }
+    }
+    true
+}
+
+fn can_claim(hand: Cards, state: &GameState) -> bool {
+    if !state.current_trick.is_empty() {
+        return false;
+    }
+    let heart_losers = losers(Suit::Hearts, hand, &state);
+    let other_losers = losers(Suit::Spades, hand, &state)
+        + losers(Suit::Diamonds, hand, &state)
+        + losers(Suit::Clubs, hand, &state);
+    return if state.played.contains_any(Cards::HEARTS) {
+        heart_losers + other_losers <= 0
+    } else {
+        other_losers <= 0 && heart_losers + other_losers <= 0
+    };
+}
+
+fn losers(suit: Suit, hand: Cards, state: &GameState) -> i8 {
+    let mut hand = hand & suit.cards();
+    let mut remaining = suit.cards() - hand - state.played;
+    let nine = suit.with_rank(Rank::Nine);
+    let mut legal_plays = if hand.len() == 1 || state.led_suits.contains_any(suit.cards()) {
+        hand
+    } else {
+        hand - state.charged_cards()
+    };
+    let mut had_winner = false;
+
+    loop {
+        if hand.is_empty() {
+            return 0;
+        }
+        if remaining.is_empty() {
+            return if hand.contains(nine) { -1 } else { 0 };
+        }
+        let top = if remaining == nine.into() {
+            nine
+        } else {
+            (remaining - nine).max()
+        };
+        if top > legal_plays.max() {
+            if had_winner && hand.contains(nine) {
+                hand -= nine;
+                remaining -= remaining.min();
+                continue;
+            }
+            if top == nine && hand.len() == 2 && hand.max() > top {
+                return 0;
+            }
+            return if top > hand.max() {
+                hand.len()
+            } else {
+                legal_plays.len()
+            } as i8;
+        }
+        let winners: Cards = legal_plays.into_iter().filter(|c| *c > top).collect();
+        if winners == nine.into() {
+            hand -= nine;
+            remaining -= remaining.min();
+            if hand.is_empty() {
+                return -1;
+            }
+            hand -= hand.min();
+            if !remaining.is_empty() {
+                remaining -= remaining.min();
+            }
+        } else {
+            hand -= (winners - nine).min();
+            remaining -= remaining.min();
+        }
+        legal_plays = hand;
+        had_winner = true;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_losers() {
+        fn case(hand: &str, remaining: &str, can_lead_charged: bool) -> i8 {
+            let hand = format!("{}S", hand).parse().unwrap();
+            let remaining: Cards = format!("{}S", remaining).parse().unwrap();
+            let mut state = GameState::new();
+            state.played = Cards::SPADES - hand - remaining;
+            if !can_lead_charged {
+                state.charged[0] = Cards::QUEEN_SPADES;
+            }
+            losers(Suit::Spades, hand, &state)
+        }
+        assert_eq!(0, case("AKQ", "23", true));
+        assert_eq!(0, case("AK", "234", true));
+        assert_eq!(-1, case("AK9", "23", true));
+        assert_eq!(-1, case("A9", "23", true));
+        assert_eq!(-1, case("A9", "234", true));
+        assert_eq!(0, case("A92", "34", true));
+        assert_eq!(-1, case("A92", "3", true));
+        assert_eq!(0, case("A", "9", true));
+        assert_eq!(-1, case("A9", "J", true));
+        assert_eq!(0, case("A9", "QJ", true));
+        assert_eq!(0, case("A9", "KQJ", true));
+        assert_eq!(1, case("A93", "KQJ", true));
+        assert_eq!(2, case("A83", "KQJ", true));
+        assert_eq!(0, case("A93", "QJ", true));
+        assert_eq!(0, case("J8", "954", true));
+        assert_eq!(1, case("J8", "T954", true));
+        assert_eq!(3, case("K93", "AQJ", true));
+        assert_eq!(2, case("K3", "AQJ", true));
+        assert_eq!(1, case("8", "9", true));
+
+        assert_eq!(1, case("Q8", "T", false));
+        assert_eq!(0, case("Q8", "9", false));
+        assert_eq!(0, case("Q8", "4", false));
+        assert_eq!(0, case("Q9", "4", false));
+        assert_eq!(0, case("Q93", "4", false));
+        assert_eq!(-1, case("Q95", "4", false));
+        assert_eq!(0, case("Q", "T", false));
+        assert_eq!(1, case("Q", "K", false));
+    }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -349,29 +349,14 @@ impl Games {
                 Some(seat) => {
                     game.verify_play(game_id, seat, card)?;
                     let mut events = vec![GameEvent::Play { seat, card }];
-                    if game.state.played | card == Cards::ALL {
-                        match game.state.phase {
-                            GamePhase::PlayLeft => {
-                                events.push(deal(game.seed, PassDirection::Right))
-                            }
-                            GamePhase::PlayRight => {
-                                events.push(deal(game.seed, PassDirection::Across))
-                            }
-                            GamePhase::PlayAcross => {
-                                events.push(deal(game.seed, PassDirection::Keeper))
-                            }
-                            _ => {}
-                        };
+                    let ends_hand = game.state.played | card == Cards::ALL;
+                    if ends_hand {
+                        game.add_deal_event(&mut events);
                     }
                     self.db.run_with_retry(|tx| {
                         persist_events(&tx, game_id, game.events.len(), &events)?;
-                        if game.state.played | card == Cards::ALL
-                            && game.state.phase == GamePhase::PlayKeeper
-                        {
-                            tx.execute::<&[&dyn ToSql]>(
-                                "UPDATE game SET completed_time = ? WHERE game_id = ?",
-                                &[&util::timestamp(), &game_id],
-                            )?;
+                        if ends_hand {
+                            game.finish_if_keeper(&tx, game_id)?;
                         }
                         Ok(())
                     })?;
@@ -424,21 +409,31 @@ impl Games {
         game_id: GameId,
         user_id: UserId,
         claimer: Seat,
-    ) -> Result<(), CardsError> {
+    ) -> Result<bool, CardsError> {
         let result = self
             .with_game(game_id, |game| match game.seat(user_id) {
                 None => Err(CardsError::InvalidPlayer(user_id, game_id)),
                 Some(seat) => {
                     game.verify_accept_claim(game_id, claimer, seat)?;
-                    let event = GameEvent::AcceptClaim {
+                    let mut events = vec![GameEvent::AcceptClaim {
                         claimer,
                         acceptor: seat,
-                    };
+                    }];
+                    let ends_hand = game.state.claims.will_successfully_claim(claimer, seat);
+                    if ends_hand {
+                        game.add_deal_event(&mut events);
+                    }
                     self.db.run_with_retry(|tx| {
-                        persist_events(&tx, game_id, game.events.len(), &[event.clone()])
+                        persist_events(&tx, game_id, game.events.len(), &events)?;
+                        if ends_hand {
+                            game.finish_if_keeper(&tx, game_id)?;
+                        }
+                        Ok(())
                     })?;
-                    game.apply(&event, |g, e| g.broadcast(e));
-                    Ok(())
+                    for event in events {
+                        game.apply(&event, |g, e| g.broadcast(e));
+                    }
+                    Ok(game.state.phase == GamePhase::Complete)
                 }
             })
             .await;
@@ -670,24 +665,36 @@ impl Game {
                     let play_status = self.play_status_event(self.state.next_player.unwrap());
                     broadcast(&mut *self, &play_status);
                 } else {
-                    let hand_complete = GameEvent::HandComplete {
-                        north_score: self.state.score(Seat::North),
-                        east_score: self.state.score(Seat::East),
-                        south_score: self.state.score(Seat::South),
-                        west_score: self.state.score(Seat::West),
-                    };
-                    broadcast(&mut *self, &hand_complete);
+                    self.finish_hand(broadcast);
                 }
-                if self.state.phase.is_complete() {
-                    let seed = if let GameEvent::Sit { seed, .. } = &self.events[0] {
-                        seed.clone()
-                    } else {
-                        panic!("First event must be a sit event");
-                    };
-                    broadcast(&mut *self, &GameEvent::GameComplete { seed });
+            }
+            GameEvent::AcceptClaim { claimer, .. } => {
+                if self.state.claims.successfully_claimed(*claimer) {
+                    self.finish_hand(broadcast);
                 }
             }
             _ => {}
+        }
+    }
+
+    fn finish_hand<F>(&mut self, mut broadcast: F)
+    where
+        F: FnMut(&mut Game, &GameEvent),
+    {
+        let hand_complete = GameEvent::HandComplete {
+            north_score: self.state.score(Seat::North),
+            east_score: self.state.score(Seat::East),
+            south_score: self.state.score(Seat::South),
+            west_score: self.state.score(Seat::West),
+        };
+        broadcast(&mut *self, &hand_complete);
+        if self.state.phase.is_complete() {
+            let seed = if let GameEvent::Sit { seed, .. } = &self.events[0] {
+                seed.clone()
+            } else {
+                panic!("First event must be a sit event");
+            };
+            broadcast(&mut *self, &GameEvent::GameComplete { seed });
         }
     }
 
@@ -860,6 +867,25 @@ impl Game {
         }
         if !self.state.claims.is_claiming(claimer) {
             return Err(CardsError::NotClaiming(self.state.players[claimer.idx()]));
+        }
+        Ok(())
+    }
+
+    fn add_deal_event(&self, events: &mut Vec<GameEvent>) {
+        match self.state.phase {
+            GamePhase::PlayLeft => events.push(deal(self.seed, PassDirection::Right)),
+            GamePhase::PlayRight => events.push(deal(self.seed, PassDirection::Across)),
+            GamePhase::PlayAcross => events.push(deal(self.seed, PassDirection::Keeper)),
+            _ => {}
+        };
+    }
+
+    fn finish_if_keeper(&self, tx: &Transaction, game_id: GameId) -> Result<(), CardsError> {
+        if self.state.phase == GamePhase::PlayKeeper {
+            tx.execute::<&[&dyn ToSql]>(
+                "UPDATE game SET completed_time = ? WHERE game_id = ?",
+                &[&util::timestamp(), &game_id],
+            )?;
         }
         Ok(())
     }

--- a/src/game/claim.rs
+++ b/src/game/claim.rs
@@ -12,6 +12,16 @@ impl ClaimState {
         }
     }
 
+    pub fn will_successfully_claim(&self, claimer: Seat, acceptor: Seat) -> bool {
+        let mut accepts = self.accepts[claimer.idx()];
+        accepts[acceptor.idx()] = true;
+        accepts.iter().all(|b| *b)
+    }
+
+    pub fn successfully_claimed(&self, claimer: Seat) -> bool {
+        self.accepts[claimer.idx()].iter().all(|b| *b)
+    }
+
     pub fn is_claiming(&self, seat: Seat) -> bool {
         self.accepts[seat.idx()][seat.idx()]
     }
@@ -26,7 +36,7 @@ impl ClaimState {
 
     pub fn accept(&mut self, claimer: Seat, acceptor: Seat) -> bool {
         self.accepts[claimer.idx()][acceptor.idx()] = true;
-        self.accepts[claimer.idx()].iter().all(|b| *b)
+        self.successfully_claimed(claimer)
     }
 
     pub fn reject(&mut self, claimer: Seat) {

--- a/src/test.rs
+++ b/src/test.rs
@@ -452,17 +452,14 @@ async fn test_bot_game() -> Result<(), CardsError> {
         let players = games.start_game(game_id)?;
         lobby.start_game(game_id, players).await;
         let mut rx = games.subscribe(game_id, UserId::new()).await?;
-        let mut plays = 0;
+        let mut game_complete = false;
         while let Some(event) = rx.recv().await {
-            match event {
-                GameEvent::Play { .. } => {
-                    plays += 1;
-                }
-                GameEvent::GameComplete { .. } => break,
-                _ => {}
+            if let GameEvent::GameComplete { .. } = event {
+                game_complete = true;
+                break;
             }
         }
-        assert_eq!(plays, 208);
+        assert!(game_complete);
         Ok(())
     }
     let runner = TestRunner::new();


### PR DESCRIPTION
bots will accept claims if the claimer's hand is able to take all
remaining tricks with best play regardless of how everyone else's cards
are distributed.

bots will make claims when they cannot avoid taking all tricks.

bots will only make or accept claims when the current trick is empty.

not merging this directly because this needs fe support. after making a
claim, a bot will not make a play until their claim is accepted by all
players, or until it is rejected (in which case they'll just claim
again).