### PR TITLE
Fix bug tracking charges in snapshotter.

### DIFF
--- a/packages/game/src/game/stateSnapshot.ts
+++ b/packages/game/src/game/stateSnapshot.ts
@@ -176,7 +176,7 @@ export function withCharge(player: TurboHearts.Player, cards: Card[]) {
   }
   return {
     ...player,
-    charged: cards,
+    charged: [...player.charged, ...cards],
     hand
   };
 }


### PR DESCRIPTION
Fixes https://github.com/tjwilson90/turbo-hearts/issues/78

@blee-palantir, this is insidious. Because we have two states, the snapshots and the sprites themselves, it's hard to detect bugs in the first. The sprites were being updated correctly from step to step, but not when snapping to the state. I wonder if this is causing other bugs...