### PR TITLE
fix bot claims

### DIFF
--- a/turbo-hearts-api/src/bot/simulate.rs
+++ b/turbo-hearts-api/src/bot/simulate.rs
@@ -38,9 +38,9 @@ impl SimulateBot {
                     do_charges(&mut game, hands).await;
                     do_passes(&mut game);
                     do_charges(&mut game, hands).await;
-                    for seat in &Seat::VALUES {
+                    for &seat in &Seat::VALUES {
                         if hands[seat.idx()].contains(Card::TwoClubs) {
-                            game.next_actor = Some(*seat);
+                            game.next_actor = Some(seat);
                             break;
                         }
                     }
@@ -199,8 +199,8 @@ fn make_hands(bot_state: &BotState, game_state: &GameState, void: VoidState) -> 
     if receiver != bot_state.seat {
         hands[receiver.idx()] |= bot_state.pre_pass_hand - bot_state.post_pass_hand;
     }
-    for seat in &Seat::VALUES {
-        hands[seat.idx()] |= game_state.charges.charges(*seat);
+    for &seat in &Seat::VALUES {
+        hands[seat.idx()] |= game_state.charges.charges(seat);
         hands[seat.idx()] -= game_state.played;
     }
     let unplayed = Cards::ALL - game_state.played;
@@ -243,10 +243,10 @@ impl State {
         if self.cards.is_empty() {
             return true;
         }
-        for seat in &Seat::VALUES {
+        for &seat in &Seat::VALUES {
             let mut available = 0;
-            for suit in &Suit::VALUES {
-                if !self.void.is_void(*seat, *suit) {
+            for &suit in &Suit::VALUES {
+                if !self.void.is_void(seat, suit) {
                     available += (self.unassigned & suit.cards()).len();
                 }
             }
@@ -257,11 +257,11 @@ impl State {
         }
         let card = self.cards.pop().unwrap();
         self.unassigned -= card;
-        for seat in &Seat::VALUES {
+        for &seat in &Seat::VALUES {
             if self.hands[seat.idx()].len() >= self.sizes[seat.idx()] {
                 continue;
             }
-            if self.void.is_void(*seat, card.suit()) {
+            if self.void.is_void(seat, card.suit()) {
                 continue;
             }
             self.hands[seat.idx()] |= card;

--- a/turbo-hearts-api/src/game.rs
+++ b/turbo-hearts-api/src/game.rs
@@ -486,9 +486,9 @@ impl Game {
     }
 
     fn owner(&self, card: Card) -> Seat {
-        for seat in &Seat::VALUES {
+        for &seat in &Seat::VALUES {
             if self.post_pass_hand[seat.idx()].contains(card) {
-                return *seat;
+                return seat;
             }
         }
         unreachable!()
@@ -845,7 +845,7 @@ impl Game {
 fn seat(players: [UserId; 4], user_id: UserId) -> Option<Seat> {
     players
         .iter()
-        .position(|id| *id == user_id)
+        .position(|&id| id == user_id)
         .map(|idx| Seat::VALUES[idx])
 }
 

--- a/turbo-hearts-api/src/game/charge.rs
+++ b/turbo-hearts-api/src/game/charge.rs
@@ -80,8 +80,8 @@ mod test {
     fn no_charges() {
         let state = ChargeState::new();
         assert_eq!(state.all_charges(), Cards::NONE);
-        for seat in &Seat::VALUES {
-            assert_eq!(state.charges(*seat), Cards::NONE);
+        for &seat in &Seat::VALUES {
+            assert_eq!(state.charges(seat), Cards::NONE);
         }
         for card in Cards::ALL {
             assert!(!state.is_charged(card));

--- a/turbo-hearts-api/src/game/claim.rs
+++ b/turbo-hearts-api/src/game/claim.rs
@@ -55,12 +55,12 @@ mod test {
     #[test]
     fn no_claim() {
         let state = ClaimState::new();
-        for s1 in &Seat::VALUES {
-            assert!(!state.successfully_claimed(*s1));
-            assert!(!state.is_claiming(*s1));
-            for s2 in &Seat::VALUES {
-                assert!(!state.will_successfully_claim(*s1, *s2));
-                assert!(!state.has_accepted(*s1, *s2));
+        for &s1 in &Seat::VALUES {
+            assert!(!state.successfully_claimed(s1));
+            assert!(!state.is_claiming(s1));
+            for &s2 in &Seat::VALUES {
+                assert!(!state.will_successfully_claim(s1, s2));
+                assert!(!state.has_accepted(s1, s2));
             }
         }
     }
@@ -69,19 +69,19 @@ mod test {
     fn claim() {
         let mut state = ClaimState::new();
         state.claim(Seat::East);
-        for s1 in &Seat::VALUES {
-            assert!(!state.successfully_claimed(*s1));
-            if *s1 == Seat::East {
-                assert!(state.is_claiming(*s1));
+        for &s1 in &Seat::VALUES {
+            assert!(!state.successfully_claimed(s1));
+            if s1 == Seat::East {
+                assert!(state.is_claiming(s1));
             } else {
-                assert!(!state.is_claiming(*s1));
+                assert!(!state.is_claiming(s1));
             }
-            for s2 in &Seat::VALUES {
-                assert!(!state.will_successfully_claim(*s1, *s2));
-                if *s1 == Seat::East && *s2 == Seat::East {
-                    assert!(state.has_accepted(*s1, *s2));
+            for &s2 in &Seat::VALUES {
+                assert!(!state.will_successfully_claim(s1, s2));
+                if s1 == Seat::East && s2 == Seat::East {
+                    assert!(state.has_accepted(s1, s2));
                 } else {
-                    assert!(!state.has_accepted(*s1, *s2));
+                    assert!(!state.has_accepted(s1, s2));
                 }
             }
         }
@@ -92,19 +92,19 @@ mod test {
         let mut state = ClaimState::new();
         state.claim(Seat::East);
         state.accept(Seat::East, Seat::North);
-        for s1 in &Seat::VALUES {
-            assert!(!state.successfully_claimed(*s1));
-            if *s1 == Seat::East {
-                assert!(state.is_claiming(*s1));
+        for &s1 in &Seat::VALUES {
+            assert!(!state.successfully_claimed(s1));
+            if s1 == Seat::East {
+                assert!(state.is_claiming(s1));
             } else {
-                assert!(!state.is_claiming(*s1));
+                assert!(!state.is_claiming(s1));
             }
-            for s2 in &Seat::VALUES {
-                assert!(!state.will_successfully_claim(*s1, *s2));
-                if *s1 == Seat::East && (*s2 == Seat::East || *s2 == Seat::North) {
-                    assert!(state.has_accepted(*s1, *s2));
+            for &s2 in &Seat::VALUES {
+                assert!(!state.will_successfully_claim(s1, s2));
+                if s1 == Seat::East && (s2 == Seat::East || s2 == Seat::North) {
+                    assert!(state.has_accepted(s1, s2));
                 } else {
-                    assert!(!state.has_accepted(*s1, *s2));
+                    assert!(!state.has_accepted(s1, s2));
                 }
             }
         }
@@ -116,23 +116,23 @@ mod test {
         state.claim(Seat::East);
         state.accept(Seat::East, Seat::North);
         state.accept(Seat::East, Seat::South);
-        for s1 in &Seat::VALUES {
-            assert!(!state.successfully_claimed(*s1));
-            if *s1 == Seat::East {
-                assert!(state.is_claiming(*s1));
+        for &s1 in &Seat::VALUES {
+            assert!(!state.successfully_claimed(s1));
+            if s1 == Seat::East {
+                assert!(state.is_claiming(s1));
             } else {
-                assert!(!state.is_claiming(*s1));
+                assert!(!state.is_claiming(s1));
             }
-            for s2 in &Seat::VALUES {
-                if *s1 == Seat::East && *s2 == Seat::West {
-                    assert!(state.will_successfully_claim(*s1, *s2));
+            for &s2 in &Seat::VALUES {
+                if s1 == Seat::East && s2 == Seat::West {
+                    assert!(state.will_successfully_claim(s1, s2));
                 } else {
-                    assert!(!state.will_successfully_claim(*s1, *s2));
+                    assert!(!state.will_successfully_claim(s1, s2));
                 }
-                if *s1 == Seat::East && *s2 != Seat::West {
-                    assert!(state.has_accepted(*s1, *s2));
+                if s1 == Seat::East && s2 != Seat::West {
+                    assert!(state.has_accepted(s1, s2));
                 } else {
-                    assert!(!state.has_accepted(*s1, *s2));
+                    assert!(!state.has_accepted(s1, s2));
                 }
             }
         }
@@ -145,27 +145,27 @@ mod test {
         state.accept(Seat::East, Seat::North);
         state.accept(Seat::East, Seat::South);
         state.accept(Seat::East, Seat::West);
-        for s1 in &Seat::VALUES {
-            if *s1 == Seat::East {
-                assert!(state.successfully_claimed(*s1));
+        for &s1 in &Seat::VALUES {
+            if s1 == Seat::East {
+                assert!(state.successfully_claimed(s1));
             } else {
-                assert!(!state.successfully_claimed(*s1));
+                assert!(!state.successfully_claimed(s1));
             }
-            if *s1 == Seat::East {
-                assert!(state.is_claiming(*s1));
+            if s1 == Seat::East {
+                assert!(state.is_claiming(s1));
             } else {
-                assert!(!state.is_claiming(*s1));
+                assert!(!state.is_claiming(s1));
             }
-            for s2 in &Seat::VALUES {
-                if *s1 == Seat::East {
-                    assert!(state.will_successfully_claim(*s1, *s2));
+            for &s2 in &Seat::VALUES {
+                if s1 == Seat::East {
+                    assert!(state.will_successfully_claim(s1, s2));
                 } else {
-                    assert!(!state.will_successfully_claim(*s1, *s2));
+                    assert!(!state.will_successfully_claim(s1, s2));
                 }
-                if *s1 == Seat::East {
-                    assert!(state.has_accepted(*s1, *s2));
+                if s1 == Seat::East {
+                    assert!(state.has_accepted(s1, s2));
                 } else {
-                    assert!(!state.has_accepted(*s1, *s2));
+                    assert!(!state.has_accepted(s1, s2));
                 }
             }
         }
@@ -177,12 +177,12 @@ mod test {
         state.claim(Seat::East);
         state.accept(Seat::East, Seat::North);
         state.reject(Seat::East);
-        for s1 in &Seat::VALUES {
-            assert!(!state.successfully_claimed(*s1));
-            assert!(!state.is_claiming(*s1));
-            for s2 in &Seat::VALUES {
-                assert!(!state.will_successfully_claim(*s1, *s2));
-                assert!(!state.has_accepted(*s1, *s2));
+        for &s1 in &Seat::VALUES {
+            assert!(!state.successfully_claimed(s1));
+            assert!(!state.is_claiming(s1));
+            for &s2 in &Seat::VALUES {
+                assert!(!state.will_successfully_claim(s1, s2));
+                assert!(!state.has_accepted(s1, s2));
             }
         }
     }

--- a/turbo-hearts-api/src/game/done.rs
+++ b/turbo-hearts-api/src/game/done.rs
@@ -50,9 +50,9 @@ mod test {
     #[test]
     fn empty() {
         let state = DoneState::new();
-        for seat in &Seat::VALUES {
-            assert!(!state.sent_pass(*seat));
-            assert!(!state.charged(*seat));
+        for &seat in &Seat::VALUES {
+            assert!(!state.sent_pass(seat));
+            assert!(!state.charged(seat));
         }
         assert!(!state.all_recv_pass());
         assert!(!state.all_charge());
@@ -63,9 +63,9 @@ mod test {
         let mut state = DoneState::new();
         state.send_pass(Seat::North);
         state.reset();
-        for seat in &Seat::VALUES {
-            assert!(!state.sent_pass(*seat));
-            assert!(!state.charged(*seat));
+        for &seat in &Seat::VALUES {
+            assert!(!state.sent_pass(seat));
+            assert!(!state.charged(seat));
         }
         assert!(!state.all_recv_pass());
         assert!(!state.all_charge());

--- a/turbo-hearts-server/src/lobby.rs
+++ b/turbo-hearts-server/src/lobby.rs
@@ -171,8 +171,8 @@ impl Lobby {
             if players.len() < 4 {
                 return Err(CardsError::NotEnoughPlayers);
             }
-            for seat in &Seat::VALUES {
-                if let Some(idx) = players.iter().position(|p| p.seat == Some(*seat)) {
+            for &seat in &Seat::VALUES {
+                if let Some(idx) = players.iter().position(|p| p.seat == Some(seat)) {
                     players.swap(idx, seat.idx());
                 }
             }


### PR DESCRIPTION
previously the accept claim or reject claim actions could be overwritten
and forgotten if another event came in after the claim event but before
the accept or reject action was handled.

instead, accepting or rejecting claims should not be actions; claims
should just be checked for and dealt with on every handling loop.