### PR TITLE
add example for perf testing can_claim

### DIFF
--- a/api/examples/can_claim.rs
+++ b/api/examples/can_claim.rs
@@ -1,0 +1,27 @@
+use rand::{prelude::SliceRandom, rngs::SmallRng, Rng, SeedableRng};
+use std::time::Instant;
+use turbo_hearts_api::{can_claim, Cards, GameState, Seat};
+
+fn main() {
+    let mut rng = SmallRng::from_entropy();
+    let mut max = 0;
+    let deck = Cards::ALL.into_iter().collect::<Vec<_>>();
+    let state = GameState {
+        next_actor: Some(Seat::North),
+        ..GameState::new()
+    };
+    for i in 0u64.. {
+        let seat = Seat::VALUES[rng.gen_range(0, 4)];
+        let hand = deck.choose_multiple(&mut rng, 13).cloned().collect();
+        let now = Instant::now();
+        can_claim(seat, hand, &state);
+        let elapsed = now.elapsed().as_nanos();
+        if elapsed > max {
+            max = elapsed;
+            println!(
+                "iter = {}, nanos = {}, seat = {}, hand = {}, ",
+                i, max, seat, hand
+            );
+        }
+    }
+}

--- a/api/src/bot.rs
+++ b/api/src/bot.rs
@@ -26,7 +26,11 @@ pub fn can_claim(seat: Seat, hand: Cards, state: &GameState) -> bool {
     }
     match state.next_actor {
         Some(actor) if seat == actor => {
-            for card in state.legal_plays(hand).distinct_plays(state.played) {
+            for card in state
+                .legal_plays(hand)
+                .distinct_plays(state.played)
+                .shuffled()
+            {
                 let mut state = state.clone();
                 state.apply(&GameEvent::Play { seat, card });
                 if state.current_trick.is_empty() && state.next_actor != Some(seat) {
@@ -39,7 +43,10 @@ pub fn can_claim(seat: Seat, hand: Cards, state: &GameState) -> bool {
             false
         }
         Some(actor) => {
-            for card in (Cards::ALL - state.played - hand).distinct_plays(state.played) {
+            for card in (Cards::ALL - state.played - hand)
+                .distinct_plays(state.played)
+                .shuffled()
+            {
                 let mut state = state.clone();
                 state.apply(&GameEvent::Play { seat: actor, card });
                 if state.current_trick.is_empty() && state.next_actor != Some(seat) {
@@ -60,11 +67,11 @@ fn can_leader_claim(hand: Cards, state: &GameState) -> bool {
     let other_losers = losers(Suit::Spades, hand, &state)
         + losers(Suit::Diamonds, hand, &state)
         + losers(Suit::Clubs, hand, &state);
-    return if state.played.contains_any(Cards::HEARTS) {
+    if state.played.contains_any(Cards::HEARTS) {
         heart_losers + other_losers <= 0
     } else {
         other_losers <= 0 && heart_losers + other_losers <= 0
-    };
+    }
 }
 
 fn losers(suit: Suit, hand: Cards, state: &GameState) -> i8 {

--- a/api/src/suits.rs
+++ b/api/src/suits.rs
@@ -10,11 +10,7 @@ impl Suits {
     pub const NONE: Suits = Suits { bits: 0x0 };
 
     pub fn is_empty(self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn len(self) -> usize {
-        self.bits.count_ones() as usize
+        self == Self::NONE
     }
 
     pub fn contains(self, other: Suit) -> bool {


### PR DESCRIPTION
1B random iterations found a maximum duration of 0.5 seconds, claiming
in second seat from the start of the hand with AS AKQJT654H A9D AKC.