### PR TITLE
fix dan's bugs

### DIFF
--- a/packages/game/src/const.ts
+++ b/packages/game/src/const.ts
@@ -3,13 +3,14 @@ import { PlayerCardPositions } from "./types";
 
 export const Z_BACKGROUND = 0;
 export const Z_PILE_CARDS = 100;
-export const Z_DEALING_CARDS = 500;
-export const Z_PLAYED_CARDS = 1000;
-export const Z_CHARGED_CARDS = 2000;
-export const Z_HAND_CARDS = 3000;
-export const Z_TRANSIT_CARDS = 4000;
-export const Z_NAMEPLATE = 5000;
-export const Z_BUTTON = 6000;
+export const Z_LIMBO_CARDS = 200;
+export const Z_DEALING_CARDS = 300;
+export const Z_PLAYED_CARDS = 400;
+export const Z_CHARGED_CARDS = 500;
+export const Z_HAND_CARDS = 600;
+export const Z_TRANSIT_CARDS = 700;
+export const Z_NAMEPLATE = 800;
+export const Z_BUTTON = 900;
 
 export const CARD_SCALE = 0.5;
 export const CARD_NATIVE_WIDTH = 212;

--- a/packages/game/src/game/snapshotter.ts
+++ b/packages/game/src/game/snapshotter.ts
@@ -179,10 +179,10 @@ export class Snapshotter {
           ...previous,
           index: previous.index + 1,
           event,
-          north: withDeal(previous.north, []),
-          east: withDeal(previous.east, []),
-          south: withDeal(previous.south, []),
-          west: withDeal(previous.west, [])
+          north: withAction(withDeal(previous.north, []), "none"),
+          east: withAction(withDeal(previous.east, []), "none"),
+          south: withAction(withDeal(previous.south, []), "none"),
+          west: withAction(withDeal(previous.west, []), "none")
         });
         break;
       }

--- a/packages/game/src/view/StepAnimation.ts
+++ b/packages/game/src/view/StepAnimation.ts
@@ -15,6 +15,7 @@ import {
   Z_CHARGED_CARDS,
   Z_DEALING_CARDS,
   Z_HAND_CARDS,
+  Z_LIMBO_CARDS,
   Z_PILE_CARDS,
   Z_PLAYED_CARDS,
   Z_TRANSIT_CARDS,
@@ -168,7 +169,7 @@ export class StepAnimation implements Animation {
             card.sprite.texture = this.cardTextures[card.card].texture;
           }
           finished++;
-          if (finished === started) {
+          if (finished === 52) {
             this.finished = true;
           }
         })
@@ -218,6 +219,11 @@ export class StepAnimation implements Animation {
         }
       }
     }
+    let i = Z_LIMBO_CARDS;
+    for (const card of cardsToMove) {
+      card.sprite.zIndex = i++;
+    }
+    this.zSort();
     const layout = LIMBO_POSITIONS_FOR_BOTTOM_SEAT[this.bottomSeat][event.from][this.next.pass];
     await Promise.all([
       this.animateCards(cardsToMove, layout.x, layout.y, layout.rotation),
@@ -428,7 +434,7 @@ export class StepAnimation implements Animation {
         })
         .onComplete(() => {
           finished++;
-          if (finished === started) {
+          if (finished === 52) {
             this.finished = true;
           }
         })
@@ -458,7 +464,6 @@ export class StepAnimation implements Animation {
     const cardDests = groupCards(cards, x, y, rotation, overlap, invert);
     return new Promise(resolve => {
       let finished = 0;
-      let started = 0;
       let i = 0;
       if (cards.length === 0) {
         resolve();
@@ -469,12 +474,11 @@ export class StepAnimation implements Animation {
           .easing(TWEEN.Easing.Quadratic.Out)
           .onComplete(() => {
             finished++;
-            if (finished === started) {
+            if (finished === 2 * cards.length) {
               resolve();
             }
           })
           .start();
-        started++;
         const totalRotation = rotation - card.sprite.rotation;
         // Prevent overly spinny cards
         if (Math.abs(totalRotation) > Math.PI) {
@@ -485,12 +489,11 @@ export class StepAnimation implements Animation {
           .easing(TWEEN.Easing.Quadratic.Out)
           .onComplete(() => {
             finished++;
-            if (finished === started) {
+            if (finished === 2 * cards.length) {
               resolve();
             }
           })
           .start();
-        started++;
         i++;
       }
     });

--- a/packages/game/src/view/TurboHeartsStage.ts
+++ b/packages/game/src/view/TurboHeartsStage.ts
@@ -24,6 +24,7 @@ import {
   Z_BACKGROUND,
   Z_CHARGED_CARDS,
   Z_HAND_CARDS,
+  Z_LIMBO_CARDS,
   Z_PILE_CARDS,
   Z_PLAYED_CARDS,
   CARD_DISPLAY_HEIGHT,
@@ -146,7 +147,6 @@ export class TurboHeartsStage {
 
   private picked: Set<SpriteCard> = new Set();
   private hovered: SpriteCard | undefined = undefined;
-  private initialPosition: Map<SpriteCard, number> = new Map();
   private cardMap: Map<PIXI.Sprite, SpriteCard> = new Map();
   private cardTweens: Map<PIXI.Sprite, TWEEN.Tween> = new Map();
 
@@ -360,7 +360,7 @@ export class TurboHeartsStage {
         const card = limboCards[i];
         card.sprite.position.set(limboDests[i].x, limboDests[i].y);
         card.sprite.rotation = limboPosition.rotation;
-        card.sprite.zIndex = Z_HAND_CARDS;
+        card.sprite.zIndex = Z_LIMBO_CARDS;
         this.cardContainer.addChild(card.sprite);
       }
     };
@@ -431,7 +431,6 @@ export class TurboHeartsStage {
     const spriteCards = spriteCardsOf([...this.bottom.hand, ...this.bottom.charged], legalPlays);
     for (const card of spriteCards) {
       this.cardMap.set(card.sprite, card);
-      this.initialPosition.set(card, card.sprite.position.y);
       card.sprite.interactive = true;
       card.sprite.buttonMode = true;
       card.sprite.addListener("pointertap", this.onClick);
@@ -445,11 +444,6 @@ export class TurboHeartsStage {
       tween.stop();
     }
     for (const sprite of this.cardMap.keys()) {
-      const spriteCard = this.cardMap.get(sprite)!;
-      if (!this.picked.has(spriteCard)) {
-        const pos = this.initialPosition.get(spriteCard)!;
-        sprite.position.y = pos;
-      }
       sprite.interactive = false;
       sprite.buttonMode = false;
       sprite.removeListener("pointertap", this.onClick);
@@ -458,7 +452,6 @@ export class TurboHeartsStage {
     }
     this.picked.clear();
     this.hovered = undefined;
-    this.initialPosition.clear();
     this.cardMap.clear();
     this.cardTweens.clear();
     this.emitter.emit("pick", []);
@@ -477,18 +470,14 @@ export class TurboHeartsStage {
   }
 
   private animate(card: SpriteCard) {
-    const initialPosition = this.initialPosition.get(card);
-    if (initialPosition === undefined) {
-      throw new Error("missing card to animate");
-    }
     let pos;
     const offset = CARD_DISPLAY_HEIGHT / 4;
     if (this.picked.has(card)) {
-      pos = initialPosition - 1.33 * offset;
+      pos = BOTTOM.y - 1.33 * offset;
     } else if (this.hovered === card) {
-      pos = initialPosition - offset;
+      pos = BOTTOM.y - offset;
     } else {
-      pos = initialPosition;
+      pos = BOTTOM.y;
     }
     this.tweenTo(card.sprite, pos);
   }


### PR DESCRIPTION
- set the z index of passed cards lower than cards in hand so cards
  being selected for charging show up on top
- set the player action to none on the game_complete event to disable
  interaction on the cards after the final card scrambling animation
- remove the initialPosition map which caused the weird card positions
  after claims