### PR TITLE
fix more z indexing bugs

### DIFF
--- a/packages/game/src/util/seatPositions.ts
+++ b/packages/game/src/util/seatPositions.ts
@@ -35,6 +35,11 @@ export function addToSeat(seat: Seat, n: number): Seat {
   return SEAT_ORDER[i];
 }
 
+export function subtractSeats(left: Seat, right: Seat): number {
+  let n = SEAT_ORDER.indexOf(left) - SEAT_ORDER.indexOf(right);
+  return n < 0 ? n + SEAT_ORDER.length : n;
+}
+
 /**
  * A map from a bottom Seat to all Seats in Top, Right, Bottom, Left order.
  */

--- a/packages/game/src/view/StepAnimation.ts
+++ b/packages/game/src/view/StepAnimation.ts
@@ -168,6 +168,7 @@ export class StepAnimation implements Animation {
           if (!card.hidden && card.sprite.texture === backTexture) {
             card.sprite.texture = this.cardTextures[card.card].texture;
           }
+          card.sprite.zIndex = Z_HAND_CARDS - finished;
           finished++;
           if (finished === 52) {
             this.finished = true;

--- a/packages/game/src/view/TurboHeartsStage.ts
+++ b/packages/game/src/view/TurboHeartsStage.ts
@@ -49,7 +49,7 @@ import { StepAnimation } from "./StepAnimation";
 import { spriteCardsOf } from "../util/helpers";
 import EventEmitter from "eventemitter3";
 import { emptyArray } from "../util/array";
-import { POSITION_FOR_BOTTOM_SEAT } from "../util/seatPositions";
+import { POSITION_FOR_BOTTOM_SEAT, addToSeat, subtractSeats } from "../util/seatPositions";
 
 const CHARGEABLE_CARDS: Card[] = ["TC", "JD", "AH", "QS"];
 
@@ -290,6 +290,7 @@ export class TurboHeartsStage {
 
   private snapToState(state: TurboHearts.StateSnapshot) {
     const bottomSeat = this.getBottomSeat(state);
+    const lastPlaySeat = state.event.type === "play_status" ? addToSeat(state.event.nextPlayer, -1) : "north";
     this.cardContainer.removeChildren();
 
     const layoutHand = (seat: Seat, position: Position, layout: PlayerCardPositions) => {
@@ -323,13 +324,13 @@ export class TurboHeartsStage {
       }
 
       const playCards = state[seat].plays.map(c => createSpriteCard(this.app.loader.resources, c, false));
-      const playDests = groupCards(playCards, layout.playX, layout.playY, layout.rotation, CARD_OVERLAP, false);
+      const playDests = groupCards(playCards, layout.playX, layout.playY, layout.rotation, CARD_OVERLAP, true);
       this[position].plays = playCards;
       for (let i = 0; i < playCards.length; i++) {
         const card = playCards[i];
         card.sprite.position.set(playDests[i].x, playDests[i].y);
         card.sprite.rotation = layout.rotation;
-        card.sprite.zIndex = Z_PLAYED_CARDS;
+        card.sprite.zIndex = Z_PLAYED_CARDS - subtractSeats(lastPlaySeat, seat) - 4 * (playCards.length - i);
         this.cardContainer.addChild(card.sprite);
       }
 


### PR DESCRIPTION
- on the keeper if there is no pass we need to set the z index of hand
  cards, otherwise their z index will be set to deal with is below the z
  index of charged cards

- when snapping to state we need to carefully set the z index of played
  cards so they're stacked in the actually played order instead of
  arbitrarily stacking north, east, south, then west.